### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ const sdk = new GeolocationSDK({
   signer, // signer extends ethers.Signer
 });
 const proof = await sdk.pol.getProof({
-  owner: "0x6457cb57dAF5DB29adbE7a137904b2042652E4bA", // The wallet address of the user of which you want to prove the location. This must be the IoTeX wallet address that the user associated to Metapebble.
   locations: [
     {
       from: 1676879793, // The start of the time range of interest (Unix timestamp).
@@ -33,7 +32,6 @@ const proof = await sdk.pol.getProof({
 });
 // if you want to use mock api, you can use this
 const proof = await sdk.pol.getMockProof({
-  owner: "0x6457cb57dAF5DB29adbE7a137904b2042652E4bA", // The wallet address of the user of which you want to prove the location. This must be the IoTeX wallet address that the user associated to Metapebble.
   locations: [
     {
       imei: "123456789012345", // The imei of the device, you can set any value you want


### PR DESCRIPTION
getProof and getMockProof don't accept "owner" as param. Owner address will be derived from signer.  We can remove it from the Readme